### PR TITLE
Adjusting size for images on edit presentation popup

### DIFF
--- a/src/pages/edit-presentation-page.js
+++ b/src/pages/edit-presentation-page.js
@@ -92,6 +92,10 @@ const EditPresentationPage = ({entity, track, presentation, selectionPlan, summi
       html: selectionPlanSettings.CFP_PRESENTATION_EDITION_CUSTOM_MESSAGE,
       type: "info",
       showCloseButton: true,
+      width: '40em',
+      customClass: {        
+        content: 'edit-presentation-content',
+      }      
     }).then((result) =>  {
       setShowInfoPopup(false)
     });

--- a/src/styles/edit-presentation-page.less
+++ b/src/styles/edit-presentation-page.less
@@ -197,3 +197,12 @@
 }
 
 
+
+// POPUP
+
+.edit-presentation-content {
+  img {
+    width: 100%;
+    object-fit: contain;
+  }
+}


### PR DESCRIPTION
<img width="870" alt="image" src="https://user-images.githubusercontent.com/19543853/221024642-d755f50d-e35f-4174-9ded-c593292a8687.png">

ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=3204962

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>
