### PR TITLE
feat: honor per-activity CFP reopen in the submission edit gate

### DIFF
--- a/src/components/presentations-table.js
+++ b/src/components/presentations-table.js
@@ -34,6 +34,10 @@ const PresentationsTable = ({
 
   const handleEditPresentation = (ev, presentation) => {
     ev.preventDefault();
+    // getProgressLink asks canEdit, so before the first Clock tick it would resolve every
+    // reopened presentation to /preview, and the layout's redirect guard makes that one-way.
+    // Do nothing until the clock is real rather than navigate somewhere we cannot come back from.
+    if (nowUtc == null) return;
     history.push(presentation.getProgressLink(nowUtc));
   };
 

--- a/src/components/presentations-table.js
+++ b/src/components/presentations-table.js
@@ -34,7 +34,7 @@ const PresentationsTable = ({
 
   const handleEditPresentation = (ev, presentation) => {
     ev.preventDefault();
-    history.push(presentation.getProgressLink());
+    history.push(presentation.getProgressLink(nowUtc));
   };
 
   const handleReviewPresentation = (ev, presentation) => {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -185,6 +185,7 @@
     "review_subtitle": "Your {presentation} is submitted and awaiting review by Track Chairs",
     "permission_denied": "Permission Denied",
     "no_edit": "You are not allowed to edit this presentation",
+    "submission_reopened": "Submission reopened until {end_date} {when}. Finish your changes before it closes.",
     "chair_comments": "Chair Comments",
     "presentation_material": "{presentation} Material",
     "role": "Role",

--- a/src/layouts/presentation-layout.js
+++ b/src/layouts/presentation-layout.js
@@ -51,8 +51,20 @@ class PresentationLayout extends React.Component {
             this.props.getPresentation(newId);
         }
 
-        this.presentation.updateSelectionPlan(newProps.selectionPlan);
-        this.presentation.updatePresentation(newProps.entity, newProps.track);
+        // Gated on the props each call actually reads. This component now subscribes to the
+        // clock, so props change every second; updatePresentation is not cheap or side-effect
+        // free (it recomputes allowed media uploads and grouped tags, rewrites step visibility,
+        // and writes progressNum onto the redux entity), and none of that depends on the tick.
+        // The per-tick re-render still happens, which is what locks the form on time.
+        // Identity comparison is sound here: presentation-reducer builds a new entity object on
+        // RECEIVE_PRESENTATION and PRESENTATION_UPDATED.
+        if (newProps.selectionPlan !== this.props.selectionPlan) {
+            this.presentation.updateSelectionPlan(newProps.selectionPlan);
+        }
+
+        if (newProps.entity !== this.props.entity || newProps.track !== this.props.track) {
+            this.presentation.updatePresentation(newProps.entity, newProps.track);
+        }
     }
 
     render(){
@@ -61,7 +73,10 @@ class PresentationLayout extends React.Component {
 
         if (loading || (!isNew && !entity.id)) return null;
 
-        if (!isNew && match.params.presentation_id == entity.id && !this.presentation.canEdit(nowUtc) && !location.pathname.endsWith('preview') ) {
+        // nowUtc is null until the first Clock tick. Evaluating the gate against a seed would
+        // let a fast device clock read a live grant as expired, and this redirect is one-way:
+        // the guard below skips it once already on /preview, so a corrected tick never undoes it.
+        if (!isNew && nowUtc != null && match.params.presentation_id == entity.id && !this.presentation.canEdit(nowUtc) && !location.pathname.endsWith('preview') ) {
             return(<Redirect to={`${match.url}/preview`} />);
         }
 

--- a/src/layouts/presentation-layout.js
+++ b/src/layouts/presentation-layout.js
@@ -51,16 +51,17 @@ class PresentationLayout extends React.Component {
             this.props.getPresentation(newId);
         }
 
+        this.presentation.updateSelectionPlan(newProps.selectionPlan);
         this.presentation.updatePresentation(newProps.entity, newProps.track);
     }
 
     render(){
-        let { match, entity, speaker, history, loading, location, selectionPlan, selectionPlansSettings } = this.props;
+        let { match, entity, speaker, history, loading, location, selectionPlan, selectionPlansSettings, nowUtc } = this.props;
         let isNew = !match.params.presentation_id;
 
         if (loading || (!isNew && !entity.id)) return null;
 
-        if (!isNew && match.params.presentation_id == entity.id && !this.presentation.canEdit() && !location.pathname.endsWith('preview') ) {
+        if (!isNew && match.params.presentation_id == entity.id && !this.presentation.canEdit(nowUtc) && !location.pathname.endsWith('preview') ) {
             return(<Redirect to={`${match.url}/preview`} />);
         }
 
@@ -87,13 +88,14 @@ class PresentationLayout extends React.Component {
 
 }
 
-const mapStateToProps = ({ baseState, presentationState }) => ({
+const mapStateToProps = ({ baseState, presentationState, clockState }) => ({
     speaker: baseState.speaker,
     summit: baseState.summit,
     loading: baseState.loading,
     tagGroups: baseState.tagGroups,
     selectionPlansSettings: baseState.selectionPlansSettings,
     loggedSpeaker: baseState.speaker,
+    nowUtc: clockState.nowUtc,
     ...presentationState
 })
 

--- a/src/model/presentation.js
+++ b/src/model/presentation.js
@@ -87,6 +87,10 @@ class Presentation {
      * @returns {React.ReactNode}
      */
     getStatus(nowUtc) {
+        // every branch below classifies the submission and selection windows against nowUtc, so
+        // before the first Clock tick there is no answer to give. null coerces to 0 in these
+        // comparisons, which would render a confidently wrong status; render nothing instead.
+        if (nowUtc == null) return null;
 
         const {is_published, status, selection_status, selectionPlan} = this._presentation;
         const {
@@ -152,6 +156,31 @@ class Presentation {
     }
 
     /**
+     * The operative reopen deadline, or null when a grant is not what is letting this
+     * presentation be edited. Three things must hold, mirroring the API's
+     * isSubmissionReopened(): the plan is enabled, its window has actually ENDED, and the
+     * grant is still live. "Not open" is not the same as "ended" — the window is also not
+     * open before it starts, and honoring a grant there would admit edits the API refuses.
+     *
+     * Single definition on purpose: canEdit() gates on it and the banner displays it, and if
+     * the two drifted the banner would announce a deadline that does not constrain anything —
+     * e.g. after an admin extends submission_end_date past an existing grant.
+     *
+     * @param nowUtc epoch seconds from the Clock, or null before the first tick
+     * @returns {number|null}
+     */
+    getReopenedUntil(nowUtc) {
+        if (nowUtc == null) return null;
+        if (!this._selectionPlan || this._selectionPlan.is_enabled === false) return null;
+        // ungranted arrives as null on the list feeds and '' on the detail feed, which coerces
+        // every null to empty string; a falsy check covers both
+        const until = this._presentation.submission_reopened_until;
+        if (!until) return null;
+        if (nowUtc <= this._selectionPlan.submission_end_date) return null;
+        return nowUtc < until ? until : null;
+    }
+
+    /**
      * @param nowUtc epoch seconds, server-synced via the Clock
      * @returns {boolean}
      */
@@ -164,18 +193,11 @@ class Presentation {
         if (this._selectionPlan.is_enabled === false) return false;
 
         // computed per call, not snapshotted in the constructor, so a window that ends while the
-        // page is open locks the form without a reload
+        // page is open locks the form without a reload. Still on nowBetween's local clock, as it
+        // was before this feature; the reopen check below is the part that moved to the synced
+        // one, because a 24h grant makes skew a far larger fraction than a multi-week plan window.
         const submissionIsClosed = !nowBetween(this._selectionPlan.submission_begin_date, this._selectionPlan.submission_end_date);
-        // ungranted arrives as null on the list feeds and '' on the detail feed, which coerces
-        // every null to empty string; !! just renders both false
-        const reopenedUntil = this._presentation.submission_reopened_until;
-        // a grant only counts once the window has actually ENDED, not merely whenever it is not
-        // open: submissionIsClosed is also true before the window starts, and honoring a grant
-        // there would admit edits the API refuses, since isSubmissionReopened() requires
-        // now > submission_end_date. On the trusted clock, not nowBetween's local one, because
-        // this is part of the reopen check rather than the plan window check
-        const submissionEnded = nowUtc > this._selectionPlan.submission_end_date;
-        const reopened = !!reopenedUntil && submissionEnded && nowUtc < reopenedUntil;
+        const reopened = !!this.getReopenedUntil(nowUtc);
 
         if (submissionIsClosed && !reopened) return false;
 

--- a/src/model/presentation.js
+++ b/src/model/presentation.js
@@ -157,10 +157,11 @@ class Presentation {
 
     /**
      * The operative reopen deadline, or null when a grant is not what is letting this
-     * presentation be edited. Three things must hold, mirroring the API's
-     * isSubmissionReopened(): the plan is enabled, its window has actually ENDED, and the
-     * grant is still live. "Not open" is not the same as "ended" — the window is also not
-     * open before it starts, and honoring a grant there would admit edits the API refuses.
+     * presentation be edited. Four things must hold, mirroring the API's
+     * isSubmissionReopened(): the plan is enabled, it has a submission end date, that window
+     * has actually ENDED, and the grant is still live. "Not open" is not the same as "ended" —
+     * the window is also not open before it starts, and honoring a grant there would admit
+     * edits the API refuses.
      *
      * Single definition on purpose: canEdit() gates on it and the banner displays it, and if
      * the two drifted the banner would announce a deadline that does not constrain anything —
@@ -176,6 +177,11 @@ class Presentation {
         // every null to empty string; a falsy check covers both
         const until = this._presentation.submission_reopened_until;
         if (!until) return null;
+        // no end date means no window to have ended, so there is nothing to reopen. Without this
+        // the comparison below is nowUtc <= 0 (null and '' coerce, undefined gives NaN), which is
+        // false, so the grant would be honored and the form would render against a plan every
+        // write fails on. Falsy check, matching the coercion note above.
+        if (!this._selectionPlan.submission_end_date) return null;
         if (nowUtc <= this._selectionPlan.submission_end_date) return null;
         return nowUtc < until ? until : null;
     }

--- a/src/model/presentation.js
+++ b/src/model/presentation.js
@@ -12,7 +12,7 @@
  **/
 
 import T from 'i18n-react/dist/i18n-react';
-import {formatEpoch, nowAfter, nowBetween} from "../utils/methods";
+import {formatEpoch, nowBetween} from "../utils/methods";
 
 const SelectionStatus_Accepted = 'accepted';
 const SelectionStatus_Alternate = 'alternate';
@@ -172,8 +172,9 @@ class Presentation {
         // a grant only counts once the window has actually ENDED, not merely whenever it is not
         // open: submissionIsClosed is also true before the window starts, and honoring a grant
         // there would admit edits the API refuses, since isSubmissionReopened() requires
-        // now > submission_end_date
-        const submissionEnded = nowAfter(this._selectionPlan.submission_end_date);
+        // now > submission_end_date. On the trusted clock, not nowBetween's local one, because
+        // this is part of the reopen check rather than the plan window check
+        const submissionEnded = nowUtc > this._selectionPlan.submission_end_date;
         const reopened = !!reopenedUntil && submissionEnded && nowUtc < reopenedUntil;
 
         if (submissionIsClosed && !reopened) return false;

--- a/src/model/presentation.js
+++ b/src/model/presentation.js
@@ -12,7 +12,7 @@
  **/
 
 import T from 'i18n-react/dist/i18n-react';
-import {formatEpoch, nowBetween} from "../utils/methods";
+import {formatEpoch, nowAfter, nowBetween} from "../utils/methods";
 
 const SelectionStatus_Accepted = 'accepted';
 const SelectionStatus_Alternate = 'alternate';
@@ -39,7 +39,6 @@ class Presentation {
         this._presentation.selectionPlan = summit.selection_plans.find(sp => sp.id === presentation.selection_plan_id);
         this._tagGroups = tagGroups;
         this._track = null;
-        this._submissionIsClosed = selectionPlan ? !nowBetween(selectionPlan.submission_begin_date, selectionPlan.submission_end_date) : true;
 
         this._steps = [
             {name: 'NEW', lcName: 'new', step: 0},
@@ -75,6 +74,12 @@ class Presentation {
         const currentStep = this.getCurrentStep();
 
         this._presentation.progressNum = currentStep.step;
+    }
+
+    // the plan is captured at construction, but navigating refetches it by id and swaps the copy
+    // held in redux, so a long-lived instance has to be told or canEdit keeps gating on the old one
+    updateSelectionPlan(selectionPlan) {
+        this._selectionPlan = selectionPlan;
     }
 
     /**
@@ -146,8 +151,32 @@ class Presentation {
         return (this._presentation.is_published || this._presentation.status === 'Received');
     }
 
-    canEdit() {
-        if (!this._selectionPlan || this._submissionIsClosed) return false;
+    /**
+     * @param nowUtc epoch seconds, server-synced via the Clock
+     * @returns {boolean}
+     */
+    canEdit(nowUtc) {
+        if (!this._selectionPlan) return false;
+        // the API refuses writes on a disabled plan, and a disabled one does reach client state:
+        // selection-plan-layout refetches the plan by id on navigation, that endpoint applies no
+        // enabled filter unlike the /me feed, and base-reducer swaps the filtered copy for it.
+        // Only an explicit false blocks, so a payload without the field still edits normally.
+        if (this._selectionPlan.is_enabled === false) return false;
+
+        // computed per call, not snapshotted in the constructor, so a window that ends while the
+        // page is open locks the form without a reload
+        const submissionIsClosed = !nowBetween(this._selectionPlan.submission_begin_date, this._selectionPlan.submission_end_date);
+        // ungranted arrives as null on the list feeds and '' on the detail feed, which coerces
+        // every null to empty string; !! just renders both false
+        const reopenedUntil = this._presentation.submission_reopened_until;
+        // a grant only counts once the window has actually ENDED, not merely whenever it is not
+        // open: submissionIsClosed is also true before the window starts, and honoring a grant
+        // there would admit edits the API refuses, since isSubmissionReopened() requires
+        // now > submission_end_date
+        const submissionEnded = nowAfter(this._selectionPlan.submission_end_date);
+        const reopened = !!reopenedUntil && submissionEnded && nowUtc < reopenedUntil;
+
+        if (submissionIsClosed && !reopened) return false;
 
         let speakers = this._presentation.speakers.map(s => {
             if (typeof s == 'object') return s.id;
@@ -172,9 +201,9 @@ class Presentation {
         return (!this._presentation.is_published && belongsToSP);
     }
 
-    getProgressLink() {
+    getProgressLink(nowUtc) {
 
-        if (this.canEdit()) {
+        if (this.canEdit(nowUtc)) {
 
             let step = 'summary';
 

--- a/src/pages/edit-presentation-page.js
+++ b/src/pages/edit-presentation-page.js
@@ -104,15 +104,19 @@ const EditPresentationPage = ({entity, track, presentation, selectionPlan, summi
     });
   }
 
+  // asks the model rather than re-deriving the condition, so the banner cannot announce a
+  // deadline that canEdit() does not actually gate on
+  const reopenedUntil = presentation.getReopenedUntil(nowUtc);
+
   return (
     <div className="page-wrap" id="edit-presentation-page">
       <div className="presentation-header-wrapper">
         <h2>{title} {`${selectionPlanSettings?.CFP_PRESENTATIONS_SINGULAR_LABEL || T.translate("edit_presentation.presentation")}`}</h2>
       </div>
-      {entity.submission_reopened_until > nowUtc &&
+      {reopenedUntil &&
       <div className="alert alert-warning">
         {T.translate("edit_presentation.submission_reopened", {
-          end_date: formatEpoch(entity.submission_reopened_until, "MMMM DD, YYYY h:mm a"),
+          end_date: formatEpoch(reopenedUntil, "MMMM DD, YYYY h:mm a"),
           when: moment.tz.guess(),
         })}
       </div>

--- a/src/pages/edit-presentation-page.js
+++ b/src/pages/edit-presentation-page.js
@@ -15,6 +15,8 @@ import React, {useContext, useEffect, useState} from 'react';
 import {connect} from 'react-redux';
 import T from 'i18n-react/dist/i18n-react';
 import Swal from "sweetalert2";
+import moment from "moment-timezone";
+import {formatEpoch} from "openstack-uicore-foundation/lib/utils/methods";
 import {
   savePresentation,
   completePresentation,
@@ -42,7 +44,7 @@ import {getMarketingValue} from "../components/marketing-setting";
 import '../styles/edit-presentation-page.less';
 import {SelectionPlanContext} from "../components/SelectionPlanContext";
 
-const EditPresentationPage = ({entity, track, presentation, selectionPlan, summit, match, selectionPlansSettings, showInfoPopup, setShowInfoPopup, ...props}) => {
+const EditPresentationPage = ({entity, track, presentation, selectionPlan, summit, match, selectionPlansSettings, showInfoPopup, setShowInfoPopup, nowUtc, ...props}) => {
   const {setSelectionPlanCtx} = useContext(SelectionPlanContext);
 
   const [selectionPlanSettings, setSelectionPlanSettings] = useState(null);
@@ -107,6 +109,14 @@ const EditPresentationPage = ({entity, track, presentation, selectionPlan, summi
       <div className="presentation-header-wrapper">
         <h2>{title} {`${selectionPlanSettings?.CFP_PRESENTATIONS_SINGULAR_LABEL || T.translate("edit_presentation.presentation")}`}</h2>
       </div>
+      {entity.submission_reopened_until > nowUtc &&
+      <div className="alert alert-warning">
+        {T.translate("edit_presentation.submission_reopened", {
+          end_date: formatEpoch(entity.submission_reopened_until, "MMMM DD, YYYY h:mm a"),
+          when: moment.tz.guess(),
+        })}
+      </div>
+      }
       <PresentationNav activeStep={step} progress={presentation.getPresentationProgress()} steps={navSteps} selectionPlanSettings={selectionPlanSettings} />
 
       {step === 'summary' &&
@@ -192,12 +202,13 @@ const EditPresentationPage = ({entity, track, presentation, selectionPlan, summi
   );
 }
 
-const mapStateToProps = ({baseState, presentationState}) => ({
+const mapStateToProps = ({baseState, presentationState, clockState}) => ({
   summit: baseState.summit,
   tagGroups: baseState.tagGroups,
   loading: baseState.loading,
   loggedSpeaker: baseState.speaker,
   selectionPlansSettings: baseState.selectionPlansSettings,
+  nowUtc: clockState.nowUtc,
   ...presentationState
 })
 

--- a/src/reducers/clock-reducer.js
+++ b/src/reducers/clock-reducer.js
@@ -10,11 +10,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+import moment from 'moment-timezone';
+import { REHYDRATE } from 'redux-persist';
 import { LOGOUT_USER } from 'openstack-uicore-foundation/lib/security/actions';
 import {
     UPDATE_CLOCK,
 } from '../actions/clock-actions';
-const localNowUtc = Date.now();
+// epoch SECONDS, matching the Clock ticks that replace it and every consumer of nowUtc
+const localNowUtc = moment().unix();
 
 const DEFAULT_STATE = {
     nowUtc: localNowUtc,
@@ -26,6 +29,13 @@ const clockReducer = (state = DEFAULT_STATE, action) => {
     switch (type) {
         case LOGOUT_USER:
             return DEFAULT_STATE;
+        case REHYDRATE:
+            // A persisted clock is always stale, and builds before this seed was corrected stored
+            // milliseconds. The config blacklist cannot discard it: it only filters outbound
+            // writes, while autoMergeLevel2 merges every stored key back in on rehydrate. Returning
+            // a NEW object is what suppresses that merge, since the reconciler skips any key whose
+            // substate the reducer already modified.
+            return { nowUtc: moment().unix() };
         case UPDATE_CLOCK: {
             const { timestamp } = payload;
             return { ...state, nowUtc: timestamp };

--- a/src/reducers/clock-reducer.js
+++ b/src/reducers/clock-reducer.js
@@ -10,17 +10,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-import moment from 'moment-timezone';
 import { REHYDRATE } from 'redux-persist';
 import { LOGOUT_USER } from 'openstack-uicore-foundation/lib/security/actions';
 import {
     UPDATE_CLOCK,
 } from '../actions/clock-actions';
-// epoch SECONDS, matching the Clock ticks that replace it and every consumer of nowUtc
-const localNowUtc = moment().unix();
 
+// null, not the browser clock: uicore's Clock leaves state.timestamp null until the time
+// service answers, and tick() no-ops until then, so any seed here survives for a whole round
+// trip. A device clock running fast past submission_reopened_until would make an active grant
+// read as expired, and the resulting redirect to /preview is one-way. Consumers treat null as
+// "not known yet" rather than as a time. Ticks arrive in epoch SECONDS, as does the API.
 const DEFAULT_STATE = {
-    nowUtc: localNowUtc,
+    nowUtc: null,
 };
 
 const clockReducer = (state = DEFAULT_STATE, action) => {
@@ -35,7 +37,7 @@ const clockReducer = (state = DEFAULT_STATE, action) => {
             // writes, while autoMergeLevel2 merges every stored key back in on rehydrate. Returning
             // a NEW object is what suppresses that merge, since the reconciler skips any key whose
             // substate the reducer already modified.
-            return { nowUtc: moment().unix() };
+            return { nowUtc: null };
         case UPDATE_CLOCK: {
             const { timestamp } = payload;
             return { ...state, nowUtc: timestamp };

--- a/src/store.js
+++ b/src/store.js
@@ -28,6 +28,9 @@ import clockReducer from "./reducers/clock-reducer";
 const config = {
     key: 'root',
     storage,
+    // the clock is live state — persisting it rehydrates a stale nowUtc over the seed, which is how
+    // a millisecond value written before the seed was fixed survives into the next session
+    blacklist: ['clockState'],
 }
 
 const reducers = persistCombineReducers(config, {


### PR DESCRIPTION
ref: https://app.clickup.com/t/86bba82ph

Speaker-facing half of Per-Activity CFP Reopen. An admin reopens submission for a single presentation for a time-boxed window; this makes the CFP portal honor that override, and stop honoring it the moment the window lapses.

Spec is section 5 of `sds/per-activity-cfp-reopen.md`.

## Depends on summit-api #581

`submission_reopened_until` is served by `SubmissionPresentationSerializer`, which ships in https://github.com/OpenStackweb/summit-api/pull/581. Until that merges and deploys, the field is absent from every payload this app reads, the new condition is simply falsy, and behavior is identical to today. Safe to merge and deploy ahead of the backend, but it does nothing until the backend lands.

## What changed

`canEdit()` decided editability from a snapshot taken in the constructor, so a page opened before a deadline kept rendering the edit form past it. It now computes per call and mirrors the API's `isSubmissionReopened()` on all three of its invariants:

- the selection plan is enabled
- its submission window has actually ended
- the grant is still live, measured against the server-synced clock

The second and third matter more than they look. "Not open" also covers "has not started yet", and the API refuses a grant there. A plan disabled after a grant does reach client state, because navigating refetches the plan by id and that endpoint applies no enabled filter, unlike the `/me` feed the client discovers plans through.

The clock those comparisons read was seeded with `Date.now()`, milliseconds, while uicore's `Clock`, the time service and the API's `datetime_epoch` fields are all epoch seconds. An active reopen window therefore read as long expired. It now seeds epoch seconds, matching `event-site`, `track-chairs` and `fnmeeting`.

Seeding was not sufficient on its own. `clockState` was persisted, and redux-persist's `blacklist` only filters outbound writes while `autoMergeLevel2` merges every stored key back in, so a returning user rehydrated the old millisecond value onto the very render that decides whether to redirect to `/preview`. That redirect is one way and preview offers only a Done button, so a returning speaker with a live grant could be stranded. Handling `REHYDRATE` in the reducer is what prevents that.

Also adds a banner naming the deadline while a grant is live, formatted and phrased like the submission deadline the app already renders in the header.

## Verification

No test infrastructure exists in this repository, so this was verified by driving the app against `api.dev.fnopen.com` plus targeted node checks against the real modules.

Browser, on a closed plan with the payload injected (the backend field does not exist on dev yet):

- closed plan with a live grant keeps the edit form and shows the banner
- closed plan with an expired grant, with no grant, and with the empty-string shape the reducer produces all redirect to `/preview` with no banner
- open plan with an expired grant keeps the form, so a grant is correctly irrelevant while the window is open
- **a window lapsing while the page sits open locks the form with no reload**, at the exact second the deadline passes

Node, against the real `Presentation` model and the real redux-persist reducer chain:

- eleven-case `canEdit()` truth table including pre-open, disabled, and absent-`is_enabled` payloads
- a stale plan swapped for a disabled copy and back, flipping the gate both ways
- a stale millisecond `clockState` rejected on rehydrate, with normal ticks unaffected

Not observed in a browser: `presentations-table.js`'s progress link, which required test data that could not be created without the backend. It threads an already-verified value into an already-verified function, and the adjacent pre-existing call on the same prop proves the value is in scope.

## Known limitation

If the time service accepts a request and never answers, uicore's `Clock` never ticks and `nowUtc` stays `null`, which is what `clock-reducer.js` seeds and what every consumer here treats as "no answer yet". `Clock.getServerTime()` is a bare `fetch` with no timeout of its own, and its error fallback only fires on a rejection, so this state lasts until the browser's own network timeout finally rejects the request. While it lasts:

- a submission window does not lapse client side, though the server still refuses late writes
- the submissions table is not navigable: title clicks no-op deliberately, because `getProgressLink` asks `canEdit` and a wrong answer there resolves to `/preview`, which the layout's redirect guard makes one-way. Doing nothing is recoverable, navigating is not
- the status column renders blank, since `getStatus` has no answer to give without a clock

The edit route itself is unaffected, so the admin's deep link, a bookmark or browser back all still reach the form. Recovery is automatic on tab re-focus, via the `visibilitychange` re-sync, or when the hung request finally errors.

Making the dead click visible rather than silent would need a disabled affordance and a new string; fixing the underlying hang means putting a timeout in the shared uicore `Clock`. Both are out of scope here.

Mid-session grant discovery remains a v1 gap per decision D8: a page already open when a grant is issued does not unlock until the speaker reloads or follows the admin's deep link. This app has no refetch path and adding one is a feature, not a fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a warning for reopened submissions, including the resubmission deadline.
  * Editing permissions and progress links now reflect the current time and selection plan.

* **Bug Fixes**
  * Fixed stale clock data affecting submission editability and progress links.
  * Prevented navigation when the current time is unavailable.
  * Reopened submissions now follow the correct timing and authorization rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
